### PR TITLE
evm: add message fee check to sendMessage

### DIFF
--- a/src/UniswapWormholeMessageReceiver.sol
+++ b/src/UniswapWormholeMessageReceiver.sol
@@ -91,7 +91,7 @@ contract UniswapWormholeMessageReceiver {
         require(vm.timestamp + MESSAGE_TIME_OUT_SECONDS >= block.timestamp, "Message no longer valid");
 
         // verify destination
-        (address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) = abi.decode(vm.payload,(address[], uint256[], bytes[], address, uint16));
+        (address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) = abi.decode(vm.payload, (address[], uint256[], bytes[], address, uint16));
         require (messageReceiver == address(this), "Message not for this dest");
         require (receiverChainId == BSC_CHAIN_ID, "Message not for this chain");
 
@@ -103,3 +103,5 @@ contract UniswapWormholeMessageReceiver {
         }
     }
 }
+
+

--- a/src/UniswapWormholeMessageSender.sol
+++ b/src/UniswapWormholeMessageSender.sol
@@ -24,7 +24,7 @@ interface IWormhole {
 contract UniswapWormholeMessageSender {
     string public constant NAME = "Uniswap Wormhole Message Sender";
     address public owner;
-    
+
     // consistencyLevel = 1 means finalized on Ethereum, see https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
     // `nonce` in Wormhole is a misnomer and can be safely set to a constant value.
     // In the future it could be used to communicate a payload version,
@@ -57,9 +57,17 @@ contract UniswapWormholeMessageSender {
      * @param receiverChainId chain id of the receiver chain
      */
     function sendMessage(address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) external onlyOwner payable {
-        bytes memory payload = abi.encode(targets,values,datas,messageReceiver,receiverChainId);
+        // cache wormhole instance and verify that the caller sent enough value to cover the Wormhole message fee
+        IWormhole _wormhole = wormhole;
+        uint256 messageFee = _wormhole.messageFee();
 
-        wormhole.publishMessage{value: wormhole.messageFee()}(NONCE, payload, CONSISTENCY_LEVEL);
+        require(msg.value == messageFee, "invalid message fee");
+
+        // format the message payload
+        bytes memory payload = abi.encode(targets, values, datas, messageReceiver, receiverChainId);
+
+        // send the payload by invoking the Wormhole core contract
+        _wormhole.publishMessage{value: messageFee}(NONCE, payload, CONSISTENCY_LEVEL);
 
         emit MessageSent(payload, messageReceiver);
     }

--- a/src/interfaces/IUniswapWormholeMessageSender.sol
+++ b/src/interfaces/IUniswapWormholeMessageSender.sol
@@ -4,5 +4,5 @@
 pragma solidity ^0.8.9;
 
 interface IUniswapWormholeMessageSender {
-    function sendMessage(address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) external;
+    function sendMessage(address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) external payable;
 }


### PR DESCRIPTION
The purpose of this PR is to add a fee check to the `sendMessage` method. Currently, the contract doesn't refund the caller when excess ether is passed to the contract. 